### PR TITLE
feat: add possible scratch location for chunks

### DIFF
--- a/tests/test_bigquery_writer.py
+++ b/tests/test_bigquery_writer.py
@@ -2,6 +2,7 @@
 
 import io
 import os
+from pathlib import Path
 
 import pytest
 import ujson
@@ -137,7 +138,7 @@ def test_big_query_scratch_location(
 
     client = mock_client(load_table_from_file=load_table_from_file)
     configuration.scratch_location = (
-        location if location == "memory" else tmp_path / location
+        location if location == "memory" else str(tmp_path / location)
     )
 
     with monkeypatch.context() as m:
@@ -145,9 +146,8 @@ def test_big_query_scratch_location(
         writer = configuration.get_instance()
         writer.write(data)
         if configuration.scratch_location != "memory":
-            assert configuration.scratch_location.exists()
-            assert configuration.scratch_location.is_file()
-            assert (configuration.scratch_location.read_text()) == ujson.dumps(
-                data[0].payload, ensure_ascii=False
-            )
+            assert not Path(
+                configuration.scratch_location
+            ).exists()  # should be cleaned up already
+
         assert called is True

--- a/tests/test_bigquery_writer.py
+++ b/tests/test_bigquery_writer.py
@@ -10,7 +10,7 @@ from google.api_core.exceptions import BadRequest
 
 from dabapush_gbq import GBQWriterConfiguration
 
-# pylint: disable=W0613, W0621, C0116
+# pylint: disable=W0613, W0621, C0116, R0913, R0917, I1101
 
 
 @pytest.fixture()
@@ -120,3 +120,34 @@ def test_big_query_writer_emits_utf8(monkeypatch, configuration, data, mock_clie
         writer.write(data)
         for expected, actual in zip(data, result):
             assert ujson.loads(actual) == expected.payload
+
+
+@pytest.mark.parametrize("location", ["memory", ".scratch.jsonl"])
+def test_big_query_scratch_location(
+    location, tmp_path, monkeypatch, configuration, data, mock_client
+):
+    """Should write data to BigQuery."""
+    called = False
+
+    def load_table_from_file(buffer, *args, **kwargs):
+        nonlocal called
+        called = True
+        assert isinstance(buffer, io.BufferedIOBase)
+        return type("Response", (object,), {"result": lambda *args, **kwargs: None})
+
+    client = mock_client(load_table_from_file=load_table_from_file)
+    configuration.scratch_location = (
+        location if location == "memory" else tmp_path / location
+    )
+
+    with monkeypatch.context() as m:
+        m.setattr("google.cloud.bigquery.Client", client)
+        writer = configuration.get_instance()
+        writer.write(data)
+        if configuration.scratch_location != "memory":
+            assert configuration.scratch_location.exists()
+            assert configuration.scratch_location.is_file()
+            assert (configuration.scratch_location.read_text()) == ujson.dumps(
+                data[0].payload, ensure_ascii=False
+            )
+        assert called is True


### PR DESCRIPTION
This allows to persist chunks larger than the available RAM, by introducing a `scratch_location` parameter to the configuration. This defaults to `"memory"`.
If it is given as a Path, it will open a scratch file in the specified location and pass that to BigQuery.